### PR TITLE
Remove the method createJSModules 

### DIFF
--- a/android/src/main/java/com/tuanpm/RCTMqtt/RCTMqttPackage.java
+++ b/android/src/main/java/com/tuanpm/RCTMqtt/RCTMqttPackage.java
@@ -26,12 +26,6 @@ public class RCTMqttPackage
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules()
-    {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext)
     {
         return Collections.emptyList();


### PR DESCRIPTION
createJSModules was removed as a breaking change in RN 0.47 and project does not compile with it.